### PR TITLE
Use enum instead of string for request method parameter when registering a route 

### DIFF
--- a/Examples/JsonApi/Server.cs
+++ b/Examples/JsonApi/Server.cs
@@ -1,5 +1,6 @@
 ﻿using JsonApi.Actions;
 using Swytch.App;
+using Swytch.Structures;
 
 
 SwytchApp server = new SwytchApp();
@@ -15,11 +16,11 @@ server.AddMiddleWare(async ctx =>
 Cars cars = new Cars();
 Fighters fighters = new Fighters();
 
-server.AddAction("GET","/cars/", cars.All);
-server.AddAction("GET","/car/{make}",cars.Get);
+server.AddAction(RequestMethod.GET,"/cars/", cars.All);
+server.AddAction(RequestMethod.GET,"/car/{make}",cars.Get);
 
-server.AddAction("GET","/fighters/", fighters.All);
-server.AddAction("GET","/fighter/{name}",fighters.Get);
+server.AddAction(RequestMethod.GET,"/fighters/", fighters.All);
+server.AddAction(RequestMethod.GET,"/fighter/{name}",fighters.Get);
 
 
 await server.Listen("http://127.0.0.1:8080/");

--- a/Examples/StaticFileServer/Program.cs
+++ b/Examples/StaticFileServer/Program.cs
@@ -34,8 +34,8 @@ Func<RequestContext, Task> evening = async c =>
 
 // server.AddAction("GET", "/file/{name}", fserver);
 
-server.AddAction("GET", "/", evening);
-server.AddAction("GET", "/travelling",
+server.AddAction(RequestMethod.GET, "/", evening);
+server.AddAction(RequestMethod.GET, "/travelling",
     async c => { await ResponseUtility.ServeFile(c, "traveling.html", HttpStatusCode.OK); });
 
 

--- a/Examples/WebApplication/Program.cs
+++ b/Examples/WebApplication/Program.cs
@@ -49,8 +49,8 @@ swytchApp.AddLogging();
 
 
 //Register actions
-swytchApp.AddAction("GET", "/", pageAction.HomePage);
-swytchApp.AddAction("GET", "/books", bookCollectionActions.ShowBookCollection);
-swytchApp.AddAction("GET,POST", "/addBook", bookCollectionActions.AddBook);
+swytchApp.AddAction(RequestMethod.GET, "/", pageAction.HomePage);
+swytchApp.AddAction(RequestMethod.GET, "/books", bookCollectionActions.ShowBookCollection);
+swytchApp.AddAction(new RequestMethod[] { RequestMethod.GET, RequestMethod.POST }, "/addBook", bookCollectionActions.AddBook);
 
 await swytchApp.Listen();

--- a/Swytch/App/ISwytchApp.cs
+++ b/Swytch/App/ISwytchApp.cs
@@ -26,7 +26,7 @@ public interface ISwytchApp
     /// <param name="methods">The allowed http methods that the handler should be called for</param>
     /// <param name="path">the url path that the handler should be called for</param>
     /// <param name="requestHandler">The request handler</param>
-    [Obsolete($"We recommended to use {nameof(RequestMethod)} as methods parameter instead",false)]
+    [Obsolete($"It is recommended to use the {nameof(RequestMethod)} enum type as the HTTP method(s) parameter instead of a string input.",false)]
     void AddAction(string methods, string path, Func<RequestContext, Task> requestHandler);
 
     /// <summary>

--- a/Swytch/App/ISwytchApp.cs
+++ b/Swytch/App/ISwytchApp.cs
@@ -17,14 +17,37 @@ public interface ISwytchApp
     /// <param name="middleware">The middleware method(any method that takes in RequestContext and returns a task)</param>
     void AddMiddleWare(Func<RequestContext, Task> middleware);
 
+
+
+    
     /// <summary>
     /// Registers http methods,url and the handler method 
     /// </summary>
     /// <param name="methods">The allowed http methods that the handler should be called for</param>
     /// <param name="path">the url path that the handler should be called for</param>
     /// <param name="requestHandler">The request handler</param>
+    [Obsolete($"We recommended to use {nameof(RequestMethod)} as methods parameter instead",false)]
     void AddAction(string methods, string path, Func<RequestContext, Task> requestHandler);
 
+    /// <summary>
+    /// Registers http methods,url and the handler method 
+    /// </summary>
+    /// <param name="methods">The allowed http methods that the handler should be called for</param>
+    /// <param name="path">the url path that the handler should be called for</param>
+    /// <param name="requestHandler">The request handler</param>
+    void AddAction(RequestMethod[] methods, string path, Func<RequestContext, Task> requestHandler);
+
+    
+    /// <summary>
+    /// Registers http methods,url and the handler method 
+    /// </summary>
+    /// <param name="method">The allowed http methods that the handler should be called for</param>
+    /// <param name="path">the url path that the handler should be called for</param>
+    /// <param name="requestHandler">The request handler</param>
+    void AddAction(RequestMethod method, string path, Func<RequestContext, Task> requestHandler);
+
+    
+    
     /// <summary>
     /// Registers a new database store to the collection
     /// </summary>

--- a/Swytch/App/Swytch.cs
+++ b/Swytch/App/Swytch.cs
@@ -97,7 +97,7 @@ public class SwytchApp : ISwytchApp
     /// <param name="methods">The allowed http methods that the handler should be called for</param>
     /// <param name="path">the url path that the handler should be called for</param>
     /// <param name="requestHandler">The request handler</param>
-    [Obsolete($"We recommended to use {nameof(RequestMethod)} as methods parameter instead",false)]
+    [Obsolete($"It is recommended to use the {nameof(RequestMethod)} enum type as the HTTP method(s) parameter instead of a string input.",false)]
     public void AddAction(string methods, string path, Func<RequestContext, Task> requestHandler)
     {
         string[] urlPath = path.Split("/");
@@ -109,7 +109,7 @@ public class SwytchApp : ISwytchApp
         {
             if (!Enum.IsDefined(typeof(RequestMethod), method))
             {
-                throw new Exception($"'{method}' is not correct request method");
+                throw new ArgumentException($"'{method}' is not correct request method");
             }
             newRoute.Methods.Add(method.ToRequestMethod());
         }

--- a/Swytch/App/Swytch.cs
+++ b/Swytch/App/Swytch.cs
@@ -8,6 +8,7 @@ using MySql.Data.MySqlClient;
 using Npgsql;
 using Oracle.ManagedDataAccess.Client;
 using RazorLight;
+using Swytch.Extensions;
 using Swytch.Structures;
 using Swytch.utilities;
 
@@ -90,6 +91,31 @@ public class SwytchApp : ISwytchApp
         _registeredMiddlewares.Enqueue(middleware);
     }
 
+    /// <summary>
+    /// Registers http methods,url and the handler method 
+    /// </summary>
+    /// <param name="methods">The allowed http methods that the handler should be called for</param>
+    /// <param name="path">the url path that the handler should be called for</param>
+    /// <param name="requestHandler">The request handler</param>
+    [Obsolete($"We recommended to use {nameof(RequestMethod)} as methods parameter instead",false)]
+    public void AddAction(string methods, string path, Func<RequestContext, Task> requestHandler)
+    {
+        string[] urlPath = path.Split("/");
+        string[] meths = methods.ToUpper().Split(",");
+
+        Route newRoute = new Route(requestHandler, urlPath);
+
+        foreach (String method in meths)
+        {
+            if (!Enum.IsDefined(typeof(RequestMethod), method))
+            {
+                throw new Exception($"'{method}' is not correct request method");
+            }
+            newRoute.Methods.Add(method.ToRequestMethod());
+        }
+
+        _registeredRoutes.Add(newRoute);
+    }
 
     /// <summary>
     /// Registers http methods,url and the handler method 
@@ -97,17 +123,32 @@ public class SwytchApp : ISwytchApp
     /// <param name="methods">The allowed http methods that the handler should be called for</param>
     /// <param name="path">the url path that the handler should be called for</param>
     /// <param name="requestHandler">The request handler</param>
-    public void AddAction(string methods, string path, Func<RequestContext, Task> requestHandler)
+    public void AddAction(RequestMethod[] methods, string path, Func<RequestContext, Task> requestHandler)
     {
         string[] urlPath = path.Split("/");
-        string[] meths = methods.Split(",");
+        
 
         Route newRoute = new Route(requestHandler, urlPath);
 
-        foreach (String method in meths)
-        {
-            newRoute.Methods.Add(method);
-        }
+        newRoute.Methods.AddRange(methods);
+
+        _registeredRoutes.Add(newRoute);
+    }
+
+    /// <summary>
+    /// Registers http methods,url and the handler method 
+    /// </summary>
+    /// <param name="method">The allowed http methods that the handler should be called for</param>
+    /// <param name="path">the url path that the handler should be called for</param>
+    /// <param name="requestHandler">The request handler</param>
+    public void AddAction(RequestMethod method, string path, Func<RequestContext, Task> requestHandler)
+    {
+        string[] urlPath = path.Split("/");
+        
+
+        Route newRoute = new Route(requestHandler, urlPath);
+
+        newRoute.Methods.Add(method);
 
         _registeredRoutes.Add(newRoute);
     }
@@ -207,7 +248,7 @@ public class SwytchApp : ISwytchApp
             c.Response.Headers.Set(HttpResponseHeader.CacheControl, $"max-age={_staticCacheMaxAge}");
             await ResponseUtility.ServeFile(c, filename ?? "NoFile", HttpStatusCode.OK);
         };
-        AddAction("GET", "/swytchserver/static/{filename}", fileServer);
+        AddAction(new []{ RequestMethod.GET }, "/swytchserver/static/{filename}", fileServer);
     }
 
 
@@ -425,7 +466,7 @@ public class SwytchApp : ISwytchApp
             var (matched, context) = MatchUrl(url ?? string.Empty, r, c);
             if (matched)
             {
-                if (r.Methods.Contains(c.Request.HttpMethod))
+                if (r.Methods.Contains(c.Request.HttpMethod.ToRequestMethod()))
                 {
                     try
                     {

--- a/Swytch/Extensions/RequestContextExtensions.cs
+++ b/Swytch/Extensions/RequestContextExtensions.cs
@@ -446,18 +446,15 @@ public static class RequestContextExtensions
     /// <exception cref="ArgumentOutOfRangeException"></exception>
     public static RequestMethod ToRequestMethod(this string requestMethod)
     {
-        switch (requestMethod)
+        return requestMethod switch
         {
-            case "GET":
-                return RequestMethod.GET;
-            case "POST":
-                return RequestMethod.POST;
-            case "PUT":
-                return RequestMethod.PUT;
-            case "DEL":
-                return RequestMethod.DEL;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(requestMethod), requestMethod, null);
-        }
+            "GET" => RequestMethod.GET,
+            "POST" => RequestMethod.POST,
+            "PUT" => RequestMethod.PUT,
+            "DEL" => RequestMethod.DEL,
+            "HEAD" => RequestMethod.HEAD,
+            "PATCH" => RequestMethod.PATCH,
+            _ => throw new ArgumentOutOfRangeException(nameof(requestMethod), requestMethod, null)
+        };
     }
 }

--- a/Swytch/Extensions/RequestContextExtensions.cs
+++ b/Swytch/Extensions/RequestContextExtensions.cs
@@ -435,4 +435,29 @@ public static class RequestContextExtensions
         await using System.IO.Stream writer = context.Response.OutputStream;
         await writer.WriteAsync(responseBuffer);
     }
+    
+    
+
+    /// <summary>
+    /// Convert Method string to Request Method Enum
+    /// </summary>
+    /// <param name="requestMethod"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public static RequestMethod ToRequestMethod(this string requestMethod)
+    {
+        switch (requestMethod)
+        {
+            case "GET":
+                return RequestMethod.GET;
+            case "POST":
+                return RequestMethod.POST;
+            case "PUT":
+                return RequestMethod.PUT;
+            case "DEL":
+                return RequestMethod.DEL;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(requestMethod), requestMethod, null);
+        }
+    }
 }

--- a/Swytch/README-nuget.md
+++ b/Swytch/README-nuget.md
@@ -32,7 +32,7 @@ Make the `swytch` and try it out!
 var app = new SwytchApp();
 
 //set up route 
-app.AddAction("GET", "/", async (context) => {
+app.AddAction(RequestMethod.GET, "/", async (context) => {
 
     context.ToOk("Welcome to Swytch!");
     

--- a/Swytch/Structures/RequestMethod.cs
+++ b/Swytch/Structures/RequestMethod.cs
@@ -20,7 +20,15 @@ public enum RequestMethod
     /// <summary>
     /// 
     /// </summary>
-    PUT
+    PUT,
+    /// <summary>
+    /// 
+    /// </summary>
+    PATCH,
+    /// <summary>
+    /// 
+    /// </summary>
+    HEAD
     
 }
 

--- a/Swytch/Structures/RequestMethod.cs
+++ b/Swytch/Structures/RequestMethod.cs
@@ -1,0 +1,26 @@
+﻿namespace Swytch.Structures;
+
+/// <summary>
+/// 
+/// </summary>
+public enum RequestMethod 
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    GET,
+    /// <summary>
+    /// 
+    /// </summary>
+    POST,
+    /// <summary>
+    /// 
+    /// </summary>
+    DEL,
+    /// <summary>
+    /// 
+    /// </summary>
+    PUT
+    
+}
+

--- a/Swytch/Structures/Route.cs
+++ b/Swytch/Structures/Route.cs
@@ -10,7 +10,7 @@ internal class Route
 {
     internal string[] UrlPath;
     internal Func<RequestContext, Task> RequestHandler;
-    internal List<string> Methods = new List<string>();
+    internal List<RequestMethod>  Methods = new List<RequestMethod>();
 
     internal Route(Func<RequestContext, Task> handler, string[] path)
     {

--- a/Swytch/Swytch.csproj
+++ b/Swytch/Swytch.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <PropertyGroup>
         <PackageId>Swytch</PackageId>
-        <Version>1.0.0-beta1</Version>
+        <Version>1.1.0-beta1</Version>
         <Authors>Gwalisam</Authors>
         <Company>Gwalisamz</Company>
         <Description>Lightweight, fast and alternative web framework for building high-performance, concurrent APIs and web applications easily</Description>

--- a/tests/SwytchAuthenticationTests.cs
+++ b/tests/SwytchAuthenticationTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Swytch.App;
 using Swytch.Extensions;
+using Swytch.Structures;
 using Swytch.utilities;
 using Xunit;
 
@@ -35,7 +36,7 @@ public class SwytchAuthenticationTests : IDisposable
         var responseCode = HttpStatusCode.OK;
 
 
-        _testServer.AddAction("GET", path,
+        _testServer.AddAction(new [] {RequestMethod.GET}, path,
             async c => { await c.WriteTextToStream(responseBody, responseCode); });
 
         //start the server on a different thread 
@@ -153,7 +154,7 @@ public class SwytchAuthenticationTests : IDisposable
             await Task.Delay(0);
             return AuthUtility.ValidateBasicAuthScheme(c, correctBasic);
         });
-        _testServer.AddAction("GET", path,
+        _testServer.AddAction(new [] {RequestMethod.GET}, path,
             async c => { await c.WriteTextToStream(responseBody, HttpStatusCode.OK); });
 
 
@@ -220,7 +221,7 @@ public class SwytchAuthenticationTests : IDisposable
         var tokenValidationParameters = TestHelpers.GeTokenValidationParameters();
 
 
-        _testServer.AddAction("GET", path,
+        _testServer.AddAction( new [] {RequestMethod.GET}, path,
             async c =>
             {
                 var claim = c.User.Claims.First(c => c.Type.Equals("customeClaim"));

--- a/tests/SwytchRoutingTests.cs
+++ b/tests/SwytchRoutingTests.cs
@@ -134,6 +134,8 @@ public class SwytchRoutingTests : IDisposable
     [InlineData( "/Send/", "/Send/" , RequestMethod.POST, HttpStatusCode.OK)]
     [InlineData( "/Del/", "/Delete/" , RequestMethod.DEL, HttpStatusCode.NotFound)]
     [InlineData( "/edit/", "/edit/" , RequestMethod.PUT, HttpStatusCode.OK)]
+    [InlineData( "/update/", "/update/" , RequestMethod.PATCH, HttpStatusCode.OK)]
+    [InlineData( "/heads/", "/heads/" , RequestMethod.HEAD, HttpStatusCode.OK)]
 
     public async Task Test_Request_Should_Return_As_What_Set_using_Request_Method_Enum(
         string requestPath,
@@ -171,6 +173,8 @@ public class SwytchRoutingTests : IDisposable
             RequestMethod.POST => await _httpClient.PostAsync(requestUri, new StringContent("")),
             RequestMethod.DEL => await _httpClient.DeleteAsync(requestUri),
             RequestMethod.PUT => await _httpClient.PutAsync(requestUri, new StringContent("")),
+            RequestMethod.PATCH => await _httpClient.PatchAsync(requestUri,new StringContent("")),
+            RequestMethod.HEAD => await _httpClient.SendAsync(new HttpRequestMessage() { RequestUri= new Uri(requestUri) ,Method = HttpMethod.Head}),
             _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
         };
 

--- a/tests/SwytchRoutingTests.cs
+++ b/tests/SwytchRoutingTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.Extensions.Logging;
 using Swytch.App;
+using Swytch.Structures;
 using Swytch.utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -47,7 +48,7 @@ public class SwytchRoutingTests : IDisposable
         string body)
     {
         //ARRANGE
-        _testServer.AddAction("GET", path,
+        _testServer.AddAction(new [] {RequestMethod.GET}, path,
             async c => { await ResponseUtility.WriteTextToStream(c, body, httpStatusCode); });
 
         //start the server instance on a different thread 
@@ -124,7 +125,60 @@ public class SwytchRoutingTests : IDisposable
         
         Assert.Equal(responseCode, response.StatusCode);
     }
-    
+
+
+
+    [Theory]
+    [InlineData( "/home/", "/home/" , RequestMethod.GET, HttpStatusCode.OK)]
+    [InlineData( "/homeIndex/", "/home/" , RequestMethod.GET, HttpStatusCode.NotFound)]
+    [InlineData( "/Send/", "/Send/" , RequestMethod.POST, HttpStatusCode.OK)]
+    [InlineData( "/Del/", "/Delete/" , RequestMethod.DEL, HttpStatusCode.NotFound)]
+    [InlineData( "/edit/", "/edit/" , RequestMethod.PUT, HttpStatusCode.OK)]
+
+    public async Task Test_Request_Should_Return_As_What_Set_using_Request_Method_Enum(
+        string requestPath,
+        string registeredPath,
+        RequestMethod method,
+        HttpStatusCode responseCode)
+    {
+        
+        _testServer.AddAction(method, registeredPath,
+            async c => { await ResponseUtility.WriteTextToStream(c, "Hello test", responseCode); });
+
+
+        //start the server on a different thread 
+        try
+        {
+            _testOutputHelper.WriteLine("starting server");
+            await TestHelpers.StartTestServer("http://localhost:6081/", _testServer);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Exception thrown when starting test server");
+        }
+
+
+        
+        
+        //ACT 
+        
+        await Task.Delay(10);
+        var requestUri = "http://localhost:6081" + requestPath;
+
+        HttpResponseMessage response = method switch
+        {
+            RequestMethod.GET => await _httpClient.GetAsync(requestUri),
+            RequestMethod.POST => await _httpClient.PostAsync(requestUri, new StringContent("")),
+            RequestMethod.DEL => await _httpClient.DeleteAsync(requestUri),
+            RequestMethod.PUT => await _httpClient.PutAsync(requestUri, new StringContent("")),
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+        };
+
+        //var response =  await _httpClient.GetAsync(requestUri);
+
+        
+        Assert.Equal(responseCode, response.StatusCode);
+    }
     public void Dispose()
     {
         _testServer.Stop();


### PR DESCRIPTION
Hey, 

I think it's will be better to avoid any typo mistakes and easy to maintain. 

### Summary of Changes:

- Added a new extension (`Swytch.Extensions`).
- Deprecated the `AddAction `method with `string methods` and added validation for request methods.
- Introduced two new `AddAction `method overloads to handle `RequestMethod `types.
- Updated method calls to use the new overloads.
- Improved the routing logic in `SwytchRouter `to convert `HttpMethod `into `RequestMethod`.

These changes are focused on enhancing type safety for HTTP method parameters and improving code maintainability.